### PR TITLE
bitset rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,37 +22,39 @@ MIT
 ##API
 
 * [BitSet](#BitSet)
-  * [new BitSet(nBitsOrKey)](#new_BitSet_new)
-  * [.get(idx)](#BitSet+get) ⇒ <code>boolean</code>
-  * [.set(idx)](#BitSet+set) ⇒ <code>boolean</code>
-  * [.setRange(from, to)](#BitSet+setRange) ⇒ <code>boolean</code>
-  * [.unset(idx)](#BitSet+unset) ⇒ <code>boolean</code>
-  * [.unsetRange(from, to)](#BitSet+unsetRange) ⇒ <code>boolean</code>
-  * [.toggle(idx)](#BitSet+toggle) ⇒ <code>boolean</code>
-  * [.toggleRange(from, to)](#BitSet+toggleRange) ⇒ <code>boolean</code>
-  * [.clear()](#BitSet+clear) ⇒ <code>boolean</code>
-  * [.clone()](#BitSet+clone) ⇒ <code>[BitSet](#BitSet)</code>
-  * [.dehydrate()](#BitSet+dehydrate) ⇒ <code>string</code>
-  * [.and(bsOrIdx)](#BitSet+and) ⇒ <code>[BitSet](#BitSet)</code>
-  * [.or(bsOrIdx)](#BitSet+or) ⇒ <code>[BitSet](#BitSet)</code>
-  * [.xor(bsOrIdx)](#BitSet+xor) ⇒ <code>[BitSet](#BitSet)</code>
-  * [.forEach(func)](#BitSet+forEach)
-  * [.getCardinality()](#BitSet+getCardinality) ⇒ <code>number</code>
-  * [.getIndices()](#BitSet+getIndices) ⇒ <code>Array</code>
-  * [.isSubsetOf(bitset)](#BitSet+isSubsetOf) ⇒ <code>Boolean</code>
-  * [.isEmpty()](#BitSet+isEmpty) ⇒ <code>boolean</code>
-  * [.isEqual(bs)](#BitSet+isEqual) ⇒ <code>boolean</code>
-  * [.toString()](#BitSet+toString) ⇒ <code>string</code>
-  * [.ffs(_startWord)](#BitSet+ffs) ⇒ <code>number</code>
-  * [.ffz(_startWord)](#BitSet+ffz) ⇒ <code>number</code>
-  * [.fls(_startWord)](#BitSet+fls) ⇒ <code>number</code>
-  * [.flz(_startWord)](#BitSet+flz) ⇒ <code>number</code>
-  * [.nextSetBit(idx)](#BitSet+nextSetBit) ⇒ <code>number</code>
-  * [.nextUnsetBit(idx)](#BitSet+nextUnsetBit) ⇒ <code>number</code>
-  * [.previousSetBit(idx)](#BitSet+previousSetBit) ⇒ <code>number</code>
-  * [.previousUnsetBit(idx)](#BitSet+previousUnsetBit) ⇒ <code>number</code>
+    * [new BitSet(nBitsOrKey)](#new_BitSet_new)
+    * [.get(idx)](#BitSet+get) ⇒ <code>boolean</code>
+    * [.set(idx)](#BitSet+set) ⇒ <code>boolean</code>
+    * [.setRange(from, to)](#BitSet+setRange) ⇒ <code>boolean</code>
+    * [.unset(idx)](#BitSet+unset) ⇒ <code>boolean</code>
+    * [.unsetRange(from, to)](#BitSet+unsetRange) ⇒ <code>boolean</code>
+    * [.toggle(idx)](#BitSet+toggle) ⇒ <code>boolean</code>
+    * [.toggleRange(from, to)](#BitSet+toggleRange) ⇒ <code>boolean</code>
+    * [.clear()](#BitSet+clear) ⇒ <code>boolean</code>
+    * [.clone()](#BitSet+clone) ⇒ <code>[BitSet](#BitSet)</code>
+    * [.dehydrate()](#BitSet+dehydrate) ⇒ <code>string</code>
+    * [.and(bsOrIdx)](#BitSet+and) ⇒ <code>[BitSet](#BitSet)</code>
+    * [.or(bsOrIdx)](#BitSet+or) ⇒ <code>[BitSet](#BitSet)</code>
+    * [.xor(bsOrIdx)](#BitSet+xor) ⇒ <code>[BitSet](#BitSet)</code>
+    * [.forEach(func)](#BitSet+forEach)
+    * [.rotate(index)](#BitSet+rotate) ⇒ <code>Bitset</code>
+    * [.getCardinality()](#BitSet+getCardinality) ⇒ <code>number</code>
+    * [.getIndices()](#BitSet+getIndices) ⇒ <code>Array</code>
+    * [.isSubsetOf(bs)](#BitSet+isSubsetOf) ⇒ <code>Boolean</code>
+    * [.isEmpty()](#BitSet+isEmpty) ⇒ <code>boolean</code>
+    * [.isEqual(bs)](#BitSet+isEqual) ⇒ <code>boolean</code>
+    * [.toString()](#BitSet+toString) ⇒ <code>string</code>
+    * [.ffs(_startWord)](#BitSet+ffs) ⇒ <code>number</code>
+    * [.ffz(_startWord)](#BitSet+ffz) ⇒ <code>number</code>
+    * [.fls(_startWord)](#BitSet+fls) ⇒ <code>number</code>
+    * [.flz(_startWord)](#BitSet+flz) ⇒ <code>number</code>
+    * [.nextSetBit(idx)](#BitSet+nextSetBit) ⇒ <code>number</code>
+    * [.nextUnsetBit(idx)](#BitSet+nextUnsetBit) ⇒ <code>number</code>
+    * [.previousSetBit(idx)](#BitSet+previousSetBit) ⇒ <code>number</code>
+    * [.previousUnsetBit(idx)](#BitSet+previousUnsetBit) ⇒ <code>number</code>
 
 <a name="new_BitSet_new"></a>
+
 ### new BitSet(nBitsOrKey)
 Create a new bitset. Accepts either the maximum number of bits, or a dehydrated bitset
 
@@ -62,6 +64,7 @@ Create a new bitset. Accepts either the maximum number of bits, or a dehydrated 
 | nBitsOrKey | <code>number</code> &#124; <code>string</code> | Number of bits in the set or dehydrated bitset. For speed and space concerns, the initial number of bits cannot be increased. |
 
 <a name="BitSet+get"></a>
+
 ### bitSet.get(idx) ⇒ <code>boolean</code>
 Check whether a bit at a specific index is set
 
@@ -73,6 +76,7 @@ Check whether a bit at a specific index is set
 | idx | <code>number</code> | the position of a single bit to check |
 
 <a name="BitSet+set"></a>
+
 ### bitSet.set(idx) ⇒ <code>boolean</code>
 Set a single bit
 
@@ -84,6 +88,7 @@ Set a single bit
 | idx | <code>number</code> | the position of a single bit to set |
 
 <a name="BitSet+setRange"></a>
+
 ### bitSet.setRange(from, to) ⇒ <code>boolean</code>
 Set a range of bits
 
@@ -96,6 +101,7 @@ Set a range of bits
 | to | <code>number</code> | the ending index of the range to set |
 
 <a name="BitSet+unset"></a>
+
 ### bitSet.unset(idx) ⇒ <code>boolean</code>
 Unset a single bit
 
@@ -107,6 +113,7 @@ Unset a single bit
 | idx | <code>number</code> | the position of a single bit to unset |
 
 <a name="BitSet+unsetRange"></a>
+
 ### bitSet.unsetRange(from, to) ⇒ <code>boolean</code>
 Unset a range of bits
 
@@ -119,6 +126,7 @@ Unset a range of bits
 | to | <code>number</code> | the ending index of the range to unset |
 
 <a name="BitSet+toggle"></a>
+
 ### bitSet.toggle(idx) ⇒ <code>boolean</code>
 Toggle a single bit
 
@@ -130,6 +138,7 @@ Toggle a single bit
 | idx | <code>number</code> | the position of a single bit to toggle |
 
 <a name="BitSet+toggleRange"></a>
+
 ### bitSet.toggleRange(from, to) ⇒ <code>boolean</code>
 Toggle a range of bits
 
@@ -142,18 +151,21 @@ Toggle a range of bits
 | to | <code>number</code> | the ending index of the range to toggle |
 
 <a name="BitSet+clear"></a>
+
 ### bitSet.clear() ⇒ <code>boolean</code>
 Clear an entire bitset
 
 **Kind**: instance method of <code>[BitSet](#BitSet)</code>  
 **Returns**: <code>boolean</code> - true  
 <a name="BitSet+clone"></a>
+
 ### bitSet.clone() ⇒ <code>[BitSet](#BitSet)</code>
 Clone a bitset
 
 **Kind**: instance method of <code>[BitSet](#BitSet)</code>  
 **Returns**: <code>[BitSet](#BitSet)</code> - an copy (by value) of the calling bitset  
 <a name="BitSet+dehydrate"></a>
+
 ### bitSet.dehydrate() ⇒ <code>string</code>
 Turn the bitset into a comma separated string that skips leading & trailing 0 words.
 Ends with the number of leading 0s and MAX_BIT.
@@ -163,6 +175,7 @@ Can rehydrate by passing the result into the constructor
 **Kind**: instance method of <code>[BitSet](#BitSet)</code>  
 **Returns**: <code>string</code> - representation of the bitset  
 <a name="BitSet+and"></a>
+
 ### bitSet.and(bsOrIdx) ⇒ <code>[BitSet](#BitSet)</code>
 Perform a bitwise AND on 2 bitsets or 1 bitset and 1 index.
 Both bitsets must have the same number of words, no length check is performed to prevent and overflow.
@@ -175,6 +188,7 @@ Both bitsets must have the same number of words, no length check is performed to
 | bsOrIdx | <code>[BitSet](#BitSet)</code> &#124; <code>Number</code> | a bitset or single index to check (useful for LP, DP problems) |
 
 <a name="BitSet+or"></a>
+
 ### bitSet.or(bsOrIdx) ⇒ <code>[BitSet](#BitSet)</code>
 Perform a bitwise OR on 2 bitsets or 1 bitset and 1 index.
 Both bitsets must have the same number of words, no length check is performed to prevent and overflow.
@@ -187,6 +201,7 @@ Both bitsets must have the same number of words, no length check is performed to
 | bsOrIdx | <code>[BitSet](#BitSet)</code> &#124; <code>Number</code> | a bitset or single index to check (useful for LP, DP problems) |
 
 <a name="BitSet+xor"></a>
+
 ### bitSet.xor(bsOrIdx) ⇒ <code>[BitSet](#BitSet)</code>
 Perform a bitwise XOR on 2 bitsets or 1 bitset and 1 index.
 Both bitsets must have the same number of words, no length check is performed to prevent and overflow.
@@ -199,6 +214,7 @@ Both bitsets must have the same number of words, no length check is performed to
 | bsOrIdx | <code>[BitSet](#BitSet)</code> &#124; <code>Number</code> | a bitset or single index to check (useful for LP, DP problems) |
 
 <a name="BitSet+forEach"></a>
+
 ### bitSet.forEach(func)
 Run a custom function on every set bit. Faster than iterating over the entire bitset with a `get()`
 Source code includes a nice pattern to follow if you need to break the for-loop early
@@ -209,19 +225,34 @@ Source code includes a nice pattern to follow if you need to break the for-loop 
 | --- | --- | --- |
 | func | <code>function</code> | the function to pass the next set bit to |
 
+<a name="BitSet+rotate"></a>
+
+### bitSet.rotate(index) ⇒ <code>Bitset</code>
+Rotate a bitset by an offset
+
+**Kind**: instance method of <code>[BitSet](#BitSet)</code>  
+**Returns**: <code>Bitset</code> - a new bitset that is rotated by the offset  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| index | <code>Number</code> | of current bitset that will be rotated to index 0 in the new bitset |
+
 <a name="BitSet+getCardinality"></a>
+
 ### bitSet.getCardinality() ⇒ <code>number</code>
 Get the cardinality (count of set bits) for the entire bitset
 
 **Kind**: instance method of <code>[BitSet](#BitSet)</code>  
 **Returns**: <code>number</code> - cardinality  
 <a name="BitSet+getIndices"></a>
+
 ### bitSet.getIndices() ⇒ <code>Array</code>
 Get the indices of all set bits. Useful for debugging, uses `forEach` internally
 
 **Kind**: instance method of <code>[BitSet](#BitSet)</code>  
 **Returns**: <code>Array</code> - Indices of all set bits  
 <a name="BitSet+isSubsetOf"></a>
+
 ### bitSet.isSubsetOf(bs) ⇒ <code>Boolean</code>
 Checks if one bitset is subset of another. Same thing can be done using _and_ operation and equality check,
 but then new BitSet would be created, and if one is only interested in yes/no information it would be a waste of memory
@@ -235,12 +266,14 @@ and additional GC strain.
 | bs | <code>[BitSet](#BitSet)</code> | a bitset to check |
 
 <a name="BitSet+isEmpty"></a>
+
 ### bitSet.isEmpty() ⇒ <code>boolean</code>
 Quickly determine if a bitset is empty
 
 **Kind**: instance method of <code>[BitSet](#BitSet)</code>  
 **Returns**: <code>boolean</code> - true if the entire bitset is empty, else false  
 <a name="BitSet+isEqual"></a>
+
 ### bitSet.isEqual(bs) ⇒ <code>boolean</code>
 Quickly determine if both bitsets are equal (faster than checking if the XOR of the two is === 0).
 Both bitsets must have the same number of words, no length check is performed to prevent and overflow.
@@ -253,12 +286,14 @@ Both bitsets must have the same number of words, no length check is performed to
 | bs | <code>[BitSet](#BitSet)</code> |
 
 <a name="BitSet+toString"></a>
+
 ### bitSet.toString() ⇒ <code>string</code>
 Get a string representation of the entire bitset, including leading 0s (useful for debugging)
 
 **Kind**: instance method of <code>[BitSet](#BitSet)</code>  
 **Returns**: <code>string</code> - a base 2 representation of the entire bitset  
 <a name="BitSet+ffs"></a>
+
 ### bitSet.ffs(_startWord) ⇒ <code>number</code>
 Find first set bit (useful for processing queues, breadth-first tree searches, etc.)
 
@@ -270,6 +305,7 @@ Find first set bit (useful for processing queues, breadth-first tree searches, e
 | _startWord | <code>number</code> | the word to start with (only used internally by nextSetBit) |
 
 <a name="BitSet+ffz"></a>
+
 ### bitSet.ffz(_startWord) ⇒ <code>number</code>
 Find first zero (unset bit)
 
@@ -281,6 +317,7 @@ Find first zero (unset bit)
 | _startWord | <code>number</code> | the word to start with (only used internally by nextUnsetBit) |
 
 <a name="BitSet+fls"></a>
+
 ### bitSet.fls(_startWord) ⇒ <code>number</code>
 Find last set bit
 
@@ -292,6 +329,7 @@ Find last set bit
 | _startWord | <code>number</code> | the word to start with (only used internally by previousSetBit) |
 
 <a name="BitSet+flz"></a>
+
 ### bitSet.flz(_startWord) ⇒ <code>number</code>
 Find last zero (unset bit)
 
@@ -303,6 +341,7 @@ Find last zero (unset bit)
 | _startWord | <code>number</code> | the word to start with (only used internally by previousUnsetBit) |
 
 <a name="BitSet+nextSetBit"></a>
+
 ### bitSet.nextSetBit(idx) ⇒ <code>number</code>
 Find first set bit, starting at a given index
 
@@ -314,6 +353,7 @@ Find first set bit, starting at a given index
 | idx | <code>number</code> | the starting index for the next set bit |
 
 <a name="BitSet+nextUnsetBit"></a>
+
 ### bitSet.nextUnsetBit(idx) ⇒ <code>number</code>
 Find first unset bit, starting at a given index
 
@@ -325,6 +365,7 @@ Find first unset bit, starting at a given index
 | idx | <code>number</code> | the starting index for the next unset bit |
 
 <a name="BitSet+previousSetBit"></a>
+
 ### bitSet.previousSetBit(idx) ⇒ <code>number</code>
 Find last set bit, up to a given index
 
@@ -336,6 +377,7 @@ Find last set bit, up to a given index
 | idx | <code>number</code> | the starting index for the next unset bit (going in reverse) |
 
 <a name="BitSet+previousUnsetBit"></a>
+
 ### bitSet.previousUnsetBit(idx) ⇒ <code>number</code>
 Find last unset bit, up to a given index
 

--- a/README.md
+++ b/README.md
@@ -22,39 +22,38 @@ MIT
 ##API
 
 * [BitSet](#BitSet)
-    * [new BitSet(nBitsOrKey)](#new_BitSet_new)
-    * [.get(idx)](#BitSet+get) ⇒ <code>boolean</code>
-    * [.set(idx)](#BitSet+set) ⇒ <code>boolean</code>
-    * [.setRange(from, to)](#BitSet+setRange) ⇒ <code>boolean</code>
-    * [.unset(idx)](#BitSet+unset) ⇒ <code>boolean</code>
-    * [.unsetRange(from, to)](#BitSet+unsetRange) ⇒ <code>boolean</code>
-    * [.toggle(idx)](#BitSet+toggle) ⇒ <code>boolean</code>
-    * [.toggleRange(from, to)](#BitSet+toggleRange) ⇒ <code>boolean</code>
-    * [.clear()](#BitSet+clear) ⇒ <code>boolean</code>
-    * [.clone()](#BitSet+clone) ⇒ <code>[BitSet](#BitSet)</code>
-    * [.dehydrate()](#BitSet+dehydrate) ⇒ <code>string</code>
-    * [.and(bsOrIdx)](#BitSet+and) ⇒ <code>[BitSet](#BitSet)</code>
-    * [.or(bsOrIdx)](#BitSet+or) ⇒ <code>[BitSet](#BitSet)</code>
-    * [.xor(bsOrIdx)](#BitSet+xor) ⇒ <code>[BitSet](#BitSet)</code>
-    * [.forEach(func)](#BitSet+forEach)
-    * [.circularShift(index)](#BitSet+circularShift) ⇒ <code>Bitset</code>
-    * [.getCardinality()](#BitSet+getCardinality) ⇒ <code>number</code>
-    * [.getIndices()](#BitSet+getIndices) ⇒ <code>Array</code>
-    * [.isSubsetOf(bs)](#BitSet+isSubsetOf) ⇒ <code>Boolean</code>
-    * [.isEmpty()](#BitSet+isEmpty) ⇒ <code>boolean</code>
-    * [.isEqual(bs)](#BitSet+isEqual) ⇒ <code>boolean</code>
-    * [.toString()](#BitSet+toString) ⇒ <code>string</code>
-    * [.ffs(_startWord)](#BitSet+ffs) ⇒ <code>number</code>
-    * [.ffz(_startWord)](#BitSet+ffz) ⇒ <code>number</code>
-    * [.fls(_startWord)](#BitSet+fls) ⇒ <code>number</code>
-    * [.flz(_startWord)](#BitSet+flz) ⇒ <code>number</code>
-    * [.nextSetBit(idx)](#BitSet+nextSetBit) ⇒ <code>number</code>
-    * [.nextUnsetBit(idx)](#BitSet+nextUnsetBit) ⇒ <code>number</code>
-    * [.previousSetBit(idx)](#BitSet+previousSetBit) ⇒ <code>number</code>
-    * [.previousUnsetBit(idx)](#BitSet+previousUnsetBit) ⇒ <code>number</code>
+  * [new BitSet(nBitsOrKey)](#new_BitSet_new)
+  * [.get(idx)](#BitSet+get) ⇒ <code>boolean</code>
+  * [.set(idx)](#BitSet+set) ⇒ <code>boolean</code>
+  * [.setRange(from, to)](#BitSet+setRange) ⇒ <code>boolean</code>
+  * [.unset(idx)](#BitSet+unset) ⇒ <code>boolean</code>
+  * [.unsetRange(from, to)](#BitSet+unsetRange) ⇒ <code>boolean</code>
+  * [.toggle(idx)](#BitSet+toggle) ⇒ <code>boolean</code>
+  * [.toggleRange(from, to)](#BitSet+toggleRange) ⇒ <code>boolean</code>
+  * [.clear()](#BitSet+clear) ⇒ <code>boolean</code>
+  * [.clone()](#BitSet+clone) ⇒ <code>[BitSet](#BitSet)</code>
+  * [.dehydrate()](#BitSet+dehydrate) ⇒ <code>string</code>
+  * [.and(bsOrIdx)](#BitSet+and) ⇒ <code>[BitSet](#BitSet)</code>
+  * [.or(bsOrIdx)](#BitSet+or) ⇒ <code>[BitSet](#BitSet)</code>
+  * [.xor(bsOrIdx)](#BitSet+xor) ⇒ <code>[BitSet](#BitSet)</code>
+  * [.forEach(func)](#BitSet+forEach)
+  * [.circularShift(number)](#BitSet+circularShift) ⇒ <code>Bitset</code>
+  * [.getCardinality()](#BitSet+getCardinality) ⇒ <code>number</code>
+  * [.getIndices()](#BitSet+getIndices) ⇒ <code>Array</code>
+  * [.isSubsetOf(bs)](#BitSet+isSubsetOf) ⇒ <code>Boolean</code>
+  * [.isEmpty()](#BitSet+isEmpty) ⇒ <code>boolean</code>
+  * [.isEqual(bs)](#BitSet+isEqual) ⇒ <code>boolean</code>
+  * [.toString()](#BitSet+toString) ⇒ <code>string</code>
+  * [.ffs(_startWord)](#BitSet+ffs) ⇒ <code>number</code>
+  * [.ffz(_startWord)](#BitSet+ffz) ⇒ <code>number</code>
+  * [.fls(_startWord)](#BitSet+fls) ⇒ <code>number</code>
+  * [.flz(_startWord)](#BitSet+flz) ⇒ <code>number</code>
+  * [.nextSetBit(idx)](#BitSet+nextSetBit) ⇒ <code>number</code>
+  * [.nextUnsetBit(idx)](#BitSet+nextUnsetBit) ⇒ <code>number</code>
+  * [.previousSetBit(idx)](#BitSet+previousSetBit) ⇒ <code>number</code>
+  * [.previousUnsetBit(idx)](#BitSet+previousUnsetBit) ⇒ <code>number</code>
 
 <a name="new_BitSet_new"></a>
-
 ### new BitSet(nBitsOrKey)
 Create a new bitset. Accepts either the maximum number of bits, or a dehydrated bitset
 
@@ -64,7 +63,6 @@ Create a new bitset. Accepts either the maximum number of bits, or a dehydrated 
 | nBitsOrKey | <code>number</code> &#124; <code>string</code> | Number of bits in the set or dehydrated bitset. For speed and space concerns, the initial number of bits cannot be increased. |
 
 <a name="BitSet+get"></a>
-
 ### bitSet.get(idx) ⇒ <code>boolean</code>
 Check whether a bit at a specific index is set
 
@@ -76,7 +74,6 @@ Check whether a bit at a specific index is set
 | idx | <code>number</code> | the position of a single bit to check |
 
 <a name="BitSet+set"></a>
-
 ### bitSet.set(idx) ⇒ <code>boolean</code>
 Set a single bit
 
@@ -88,7 +85,6 @@ Set a single bit
 | idx | <code>number</code> | the position of a single bit to set |
 
 <a name="BitSet+setRange"></a>
-
 ### bitSet.setRange(from, to) ⇒ <code>boolean</code>
 Set a range of bits
 
@@ -101,7 +97,6 @@ Set a range of bits
 | to | <code>number</code> | the ending index of the range to set |
 
 <a name="BitSet+unset"></a>
-
 ### bitSet.unset(idx) ⇒ <code>boolean</code>
 Unset a single bit
 
@@ -113,7 +108,6 @@ Unset a single bit
 | idx | <code>number</code> | the position of a single bit to unset |
 
 <a name="BitSet+unsetRange"></a>
-
 ### bitSet.unsetRange(from, to) ⇒ <code>boolean</code>
 Unset a range of bits
 
@@ -126,7 +120,6 @@ Unset a range of bits
 | to | <code>number</code> | the ending index of the range to unset |
 
 <a name="BitSet+toggle"></a>
-
 ### bitSet.toggle(idx) ⇒ <code>boolean</code>
 Toggle a single bit
 
@@ -138,7 +131,6 @@ Toggle a single bit
 | idx | <code>number</code> | the position of a single bit to toggle |
 
 <a name="BitSet+toggleRange"></a>
-
 ### bitSet.toggleRange(from, to) ⇒ <code>boolean</code>
 Toggle a range of bits
 
@@ -151,21 +143,18 @@ Toggle a range of bits
 | to | <code>number</code> | the ending index of the range to toggle |
 
 <a name="BitSet+clear"></a>
-
 ### bitSet.clear() ⇒ <code>boolean</code>
 Clear an entire bitset
 
 **Kind**: instance method of <code>[BitSet](#BitSet)</code>  
 **Returns**: <code>boolean</code> - true  
 <a name="BitSet+clone"></a>
-
 ### bitSet.clone() ⇒ <code>[BitSet](#BitSet)</code>
 Clone a bitset
 
 **Kind**: instance method of <code>[BitSet](#BitSet)</code>  
 **Returns**: <code>[BitSet](#BitSet)</code> - an copy (by value) of the calling bitset  
 <a name="BitSet+dehydrate"></a>
-
 ### bitSet.dehydrate() ⇒ <code>string</code>
 Turn the bitset into a comma separated string that skips leading & trailing 0 words.
 Ends with the number of leading 0s and MAX_BIT.
@@ -175,7 +164,6 @@ Can rehydrate by passing the result into the constructor
 **Kind**: instance method of <code>[BitSet](#BitSet)</code>  
 **Returns**: <code>string</code> - representation of the bitset  
 <a name="BitSet+and"></a>
-
 ### bitSet.and(bsOrIdx) ⇒ <code>[BitSet](#BitSet)</code>
 Perform a bitwise AND on 2 bitsets or 1 bitset and 1 index.
 Both bitsets must have the same number of words, no length check is performed to prevent and overflow.
@@ -188,7 +176,6 @@ Both bitsets must have the same number of words, no length check is performed to
 | bsOrIdx | <code>[BitSet](#BitSet)</code> &#124; <code>Number</code> | a bitset or single index to check (useful for LP, DP problems) |
 
 <a name="BitSet+or"></a>
-
 ### bitSet.or(bsOrIdx) ⇒ <code>[BitSet](#BitSet)</code>
 Perform a bitwise OR on 2 bitsets or 1 bitset and 1 index.
 Both bitsets must have the same number of words, no length check is performed to prevent and overflow.
@@ -201,7 +188,6 @@ Both bitsets must have the same number of words, no length check is performed to
 | bsOrIdx | <code>[BitSet](#BitSet)</code> &#124; <code>Number</code> | a bitset or single index to check (useful for LP, DP problems) |
 
 <a name="BitSet+xor"></a>
-
 ### bitSet.xor(bsOrIdx) ⇒ <code>[BitSet](#BitSet)</code>
 Perform a bitwise XOR on 2 bitsets or 1 bitset and 1 index.
 Both bitsets must have the same number of words, no length check is performed to prevent and overflow.
@@ -214,7 +200,6 @@ Both bitsets must have the same number of words, no length check is performed to
 | bsOrIdx | <code>[BitSet](#BitSet)</code> &#124; <code>Number</code> | a bitset or single index to check (useful for LP, DP problems) |
 
 <a name="BitSet+forEach"></a>
-
 ### bitSet.forEach(func)
 Run a custom function on every set bit. Faster than iterating over the entire bitset with a `get()`
 Source code includes a nice pattern to follow if you need to break the for-loop early
@@ -226,8 +211,7 @@ Source code includes a nice pattern to follow if you need to break the for-loop 
 | func | <code>function</code> | the function to pass the next set bit to |
 
 <a name="BitSet+circularShift"></a>
-
-### bitSet.circularShift(index) ⇒ <code>Bitset</code>
+### bitSet.circularShift(number) ⇒ <code>Bitset</code>
 Circular shift bitset by an offset
 
 **Kind**: instance method of <code>[BitSet](#BitSet)</code>  
@@ -235,24 +219,21 @@ Circular shift bitset by an offset
 
 | Param | Type | Description |
 | --- | --- | --- |
-| index | <code>Number</code> | of current bitset that will be rotated to index 0 in the new bitset |
+| number | <code>Number</code> | of positions that the bitset that will be shifted to the right. Using a negative number will result in a left shift. |
 
 <a name="BitSet+getCardinality"></a>
-
 ### bitSet.getCardinality() ⇒ <code>number</code>
 Get the cardinality (count of set bits) for the entire bitset
 
 **Kind**: instance method of <code>[BitSet](#BitSet)</code>  
 **Returns**: <code>number</code> - cardinality  
 <a name="BitSet+getIndices"></a>
-
 ### bitSet.getIndices() ⇒ <code>Array</code>
 Get the indices of all set bits. Useful for debugging, uses `forEach` internally
 
 **Kind**: instance method of <code>[BitSet](#BitSet)</code>  
 **Returns**: <code>Array</code> - Indices of all set bits  
 <a name="BitSet+isSubsetOf"></a>
-
 ### bitSet.isSubsetOf(bs) ⇒ <code>Boolean</code>
 Checks if one bitset is subset of another. Same thing can be done using _and_ operation and equality check,
 but then new BitSet would be created, and if one is only interested in yes/no information it would be a waste of memory
@@ -266,14 +247,12 @@ and additional GC strain.
 | bs | <code>[BitSet](#BitSet)</code> | a bitset to check |
 
 <a name="BitSet+isEmpty"></a>
-
 ### bitSet.isEmpty() ⇒ <code>boolean</code>
 Quickly determine if a bitset is empty
 
 **Kind**: instance method of <code>[BitSet](#BitSet)</code>  
 **Returns**: <code>boolean</code> - true if the entire bitset is empty, else false  
 <a name="BitSet+isEqual"></a>
-
 ### bitSet.isEqual(bs) ⇒ <code>boolean</code>
 Quickly determine if both bitsets are equal (faster than checking if the XOR of the two is === 0).
 Both bitsets must have the same number of words, no length check is performed to prevent and overflow.
@@ -286,14 +265,12 @@ Both bitsets must have the same number of words, no length check is performed to
 | bs | <code>[BitSet](#BitSet)</code> |
 
 <a name="BitSet+toString"></a>
-
 ### bitSet.toString() ⇒ <code>string</code>
 Get a string representation of the entire bitset, including leading 0s (useful for debugging)
 
 **Kind**: instance method of <code>[BitSet](#BitSet)</code>  
 **Returns**: <code>string</code> - a base 2 representation of the entire bitset  
 <a name="BitSet+ffs"></a>
-
 ### bitSet.ffs(_startWord) ⇒ <code>number</code>
 Find first set bit (useful for processing queues, breadth-first tree searches, etc.)
 
@@ -305,7 +282,6 @@ Find first set bit (useful for processing queues, breadth-first tree searches, e
 | _startWord | <code>number</code> | the word to start with (only used internally by nextSetBit) |
 
 <a name="BitSet+ffz"></a>
-
 ### bitSet.ffz(_startWord) ⇒ <code>number</code>
 Find first zero (unset bit)
 
@@ -317,7 +293,6 @@ Find first zero (unset bit)
 | _startWord | <code>number</code> | the word to start with (only used internally by nextUnsetBit) |
 
 <a name="BitSet+fls"></a>
-
 ### bitSet.fls(_startWord) ⇒ <code>number</code>
 Find last set bit
 
@@ -329,7 +304,6 @@ Find last set bit
 | _startWord | <code>number</code> | the word to start with (only used internally by previousSetBit) |
 
 <a name="BitSet+flz"></a>
-
 ### bitSet.flz(_startWord) ⇒ <code>number</code>
 Find last zero (unset bit)
 
@@ -341,7 +315,6 @@ Find last zero (unset bit)
 | _startWord | <code>number</code> | the word to start with (only used internally by previousUnsetBit) |
 
 <a name="BitSet+nextSetBit"></a>
-
 ### bitSet.nextSetBit(idx) ⇒ <code>number</code>
 Find first set bit, starting at a given index
 
@@ -353,7 +326,6 @@ Find first set bit, starting at a given index
 | idx | <code>number</code> | the starting index for the next set bit |
 
 <a name="BitSet+nextUnsetBit"></a>
-
 ### bitSet.nextUnsetBit(idx) ⇒ <code>number</code>
 Find first unset bit, starting at a given index
 
@@ -365,7 +337,6 @@ Find first unset bit, starting at a given index
 | idx | <code>number</code> | the starting index for the next unset bit |
 
 <a name="BitSet+previousSetBit"></a>
-
 ### bitSet.previousSetBit(idx) ⇒ <code>number</code>
 Find last set bit, up to a given index
 
@@ -377,7 +348,6 @@ Find last set bit, up to a given index
 | idx | <code>number</code> | the starting index for the next unset bit (going in reverse) |
 
 <a name="BitSet+previousUnsetBit"></a>
-
 ### bitSet.previousUnsetBit(idx) ⇒ <code>number</code>
 Find last unset bit, up to a given index
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ MIT
     * [.or(bsOrIdx)](#BitSet+or) ⇒ <code>[BitSet](#BitSet)</code>
     * [.xor(bsOrIdx)](#BitSet+xor) ⇒ <code>[BitSet](#BitSet)</code>
     * [.forEach(func)](#BitSet+forEach)
-    * [.rotate(index)](#BitSet+rotate) ⇒ <code>Bitset</code>
+    * [.circularShift(index)](#BitSet+circularShift) ⇒ <code>Bitset</code>
     * [.getCardinality()](#BitSet+getCardinality) ⇒ <code>number</code>
     * [.getIndices()](#BitSet+getIndices) ⇒ <code>Array</code>
     * [.isSubsetOf(bs)](#BitSet+isSubsetOf) ⇒ <code>Boolean</code>
@@ -225,10 +225,10 @@ Source code includes a nice pattern to follow if you need to break the for-loop 
 | --- | --- | --- |
 | func | <code>function</code> | the function to pass the next set bit to |
 
-<a name="BitSet+rotate"></a>
+<a name="BitSet+circularShift"></a>
 
-### bitSet.rotate(index) ⇒ <code>Bitset</code>
-Rotate a bitset by an offset
+### bitSet.circularShift(index) ⇒ <code>Bitset</code>
+Circular shift bitset by an offset
 
 **Kind**: instance method of <code>[BitSet](#BitSet)</code>  
 **Returns**: <code>Bitset</code> - a new bitset that is rotated by the offset  

--- a/app/BitSet.js
+++ b/app/BitSet.js
@@ -238,8 +238,6 @@ BitSet.prototype.circularShift = function (offset) {
     rotated.arr[j] = original.arr[i] << bitShiftLeft | original.arr[afteri] >> (BITS_PER_INT - bitShiftLeft)
   }
   return rotated;
-
-  BITS_PER_INT
 };
 
 

--- a/app/BitSet.js
+++ b/app/BitSet.js
@@ -206,19 +206,40 @@ BitSet.prototype.forEach = function (func) {
 };
 
 /**
- * Rotate a bitset by an offset
+ * Circular shift bitset by an offset
  * @param {Number} index of current bitset that will be rotated to index 0 in the new bitset
  * @returns {Bitset} a new bitset that is rotated by the offset
  */
-BitSet.prototype.rotate = function (offset) {
+BitSet.prototype.circularShift = function (offset) {
+  // var original = this;
+  // const LEN = original.MAX_BIT+1
+  //
+  // var offset = (LEN + (offset % LEN) ) % LEN;
+  // var rotated = new BitSet(LEN+1);
+  // original.forEach(function(i){
+  //   var j = i+offset;
+  //   if( j > original.MAX_BIT ){ j -= LEN }
+  //   rotated.set(j)
+  // })
+  // return rotated;
+
   var original = this;
-  const LEN = original.MAX_BIT+1
-  offset = LEN + (offset%LEN); // make offset positive, i.e. -300 ~= 1 (mod 7)
-  var rotated = new BitSet(LEN+1);
-  original.forEach(function(i){
-    rotated.set(i+offset % LEN)
-  })
+  const len = original.MAX_BIT+1
+  var offset = (len + (offset % len) ) % len;
+  var rotated = new BitSet(len+1);
+
+  const wordShift = Math.floor(offset / BITS_PER_INT)
+  const bitShiftLeft = (offset % BITS_PER_INT);
+  for (let i = 0; i < original.arr.length; i++) {
+    var afteri = i+1;
+    if( afteri > original.arr.length ){ afteri -= original.arr.length }
+    var j = i+wordShift;
+    if( j > original.arr.length ){ j -= original.arr.length }
+    rotated.arr[j] = original.arr[i] << bitShiftLeft | original.arr[afteri] >> (BITS_PER_INT - bitShiftLeft)
+  }
   return rotated;
+
+  BITS_PER_INT
 };
 
 

--- a/app/BitSet.js
+++ b/app/BitSet.js
@@ -215,7 +215,7 @@ BitSet.prototype.circularShift = function (offset) {
   const LEN = original.MAX_BIT+1
 
   var offset = (LEN + (offset % LEN) ) % LEN;
-  var rotated = new BitSet(LEN+1);
+  var rotated = new BitSet(LEN);
   original.forEach(function(i){
     var j = i+offset;
     if( j > original.MAX_BIT ){ j -= LEN }

--- a/app/BitSet.js
+++ b/app/BitSet.js
@@ -230,7 +230,7 @@ BitSet.prototype.circularShift = function (offset) {
 
   const wordShift = Math.floor(offset / BITS_PER_INT)
   const bitShiftLeft = (offset % BITS_PER_INT);
-  for (let i = 0; i < original.arr.length; i++) {
+  for (i = 0; i < original.arr.length; i++) {
     var afteri = i+1;
     if( afteri > original.arr.length ){ afteri -= original.arr.length }
     var j = i+wordShift;

--- a/app/BitSet.js
+++ b/app/BitSet.js
@@ -222,33 +222,6 @@ BitSet.prototype.circularShift = function (offset) {
     rotated.set(j)
   })
   return rotated;
-  // console.log("-------------------------")
-  //
-  // console.log("rotating",this)
-  // var original = this;
-  // const len = original.MAX_BIT+1;
-  // var offset = (len + (offset % len) ) % len;
-  // var rotated = new BitSet(len);
-  //
-  // const wordShift = Math.floor(offset / BITS_PER_INT)
-  // console.log("wordshift",wordShift)
-  // const bitShiftLeft = (offset % BITS_PER_INT);
-  // console.log("bitshiftLeft",bitShiftLeft)
-  // for (i = 0; i < original.arr.length; i++) {
-  //   console.log("i",i)
-  //   var afteri = i-1;
-  //   if( afteri < 0 ){ afteri += original.arr.length }
-  //   console.log("afteri",afteri)
-  //   var j = i+wordShift;
-  //   if( j >= original.arr.length ){ j -= original.arr.length }
-  //   console.log("j",j)
-  //   rotated.arr[j] =
-  //         (original.arr[i] << bitShiftLeft) |
-  //         (original.arr[afteri] >>> (BITS_PER_INT - bitShiftLeft ))
-  // }
-  // console.log("ended up with", rotated)
-  // console.log("-------------------------")
-  // return rotated;
 };
 
 

--- a/app/BitSet.js
+++ b/app/BitSet.js
@@ -211,33 +211,44 @@ BitSet.prototype.forEach = function (func) {
  * @returns {Bitset} a new bitset that is rotated by the offset
  */
 BitSet.prototype.circularShift = function (offset) {
-  // var original = this;
-  // const LEN = original.MAX_BIT+1
-  //
-  // var offset = (LEN + (offset % LEN) ) % LEN;
-  // var rotated = new BitSet(LEN+1);
-  // original.forEach(function(i){
-  //   var j = i+offset;
-  //   if( j > original.MAX_BIT ){ j -= LEN }
-  //   rotated.set(j)
-  // })
-  // return rotated;
-
   var original = this;
-  const len = original.MAX_BIT+1
-  var offset = (len + (offset % len) ) % len;
-  var rotated = new BitSet(len+1);
+  const LEN = original.MAX_BIT+1
 
-  const wordShift = Math.floor(offset / BITS_PER_INT)
-  const bitShiftLeft = (offset % BITS_PER_INT);
-  for (i = 0; i < original.arr.length; i++) {
-    var afteri = i+1;
-    if( afteri > original.arr.length ){ afteri -= original.arr.length }
-    var j = i+wordShift;
-    if( j > original.arr.length ){ j -= original.arr.length }
-    rotated.arr[j] = original.arr[i] << bitShiftLeft | original.arr[afteri] >> (BITS_PER_INT - bitShiftLeft)
-  }
+  var offset = (LEN + (offset % LEN) ) % LEN;
+  var rotated = new BitSet(LEN+1);
+  original.forEach(function(i){
+    var j = i+offset;
+    if( j > original.MAX_BIT ){ j -= LEN }
+    rotated.set(j)
+  })
   return rotated;
+  // console.log("-------------------------")
+  //
+  // console.log("rotating",this)
+  // var original = this;
+  // const len = original.MAX_BIT+1;
+  // var offset = (len + (offset % len) ) % len;
+  // var rotated = new BitSet(len);
+  //
+  // const wordShift = Math.floor(offset / BITS_PER_INT)
+  // console.log("wordshift",wordShift)
+  // const bitShiftLeft = (offset % BITS_PER_INT);
+  // console.log("bitshiftLeft",bitShiftLeft)
+  // for (i = 0; i < original.arr.length; i++) {
+  //   console.log("i",i)
+  //   var afteri = i-1;
+  //   if( afteri < 0 ){ afteri += original.arr.length }
+  //   console.log("afteri",afteri)
+  //   var j = i+wordShift;
+  //   if( j >= original.arr.length ){ j -= original.arr.length }
+  //   console.log("j",j)
+  //   rotated.arr[j] =
+  //         (original.arr[i] << bitShiftLeft) |
+  //         (original.arr[afteri] >>> (BITS_PER_INT - bitShiftLeft ))
+  // }
+  // console.log("ended up with", rotated)
+  // console.log("-------------------------")
+  // return rotated;
 };
 
 

--- a/app/BitSet.js
+++ b/app/BitSet.js
@@ -226,30 +226,21 @@ BitSet.prototype.circularShift = function(offset) {
   var s; var t = 0; // (s)ource and (t)arget word indices
   var i; var j = 0; // current bit indices for source (i) and target (j) words
   var z = 0; // bit index for entire sequence.
-  var zz = 0
 
   offset = (BITS + (offset % BITS)) % BITS // positive, within length
-  // console.log("offset:",offset)
   var s = Math.floor(offset / BITS_PER_INT) % WORDS
   var i = offset % BITS_PER_INT
-  function __LOG(){
-    // console.log("z:",z,"j:",j,"t:",t,"i:",i,"s:",s,"sourceWordLength:",sourceWordLength)
-  }
-  while (z < BITS && zz<200){
-    zz++;
-    // console.log(T.getIndices())
+  while (z < BITS){
     var sourceWordLength = s == WORDS - 1 ? BITS_LAST_WORD : BITS_PER_INT
     var bits = S.arr[s]
-    __LOG()
-    // console.log("source bits:\n",bits.toString(2))
+
     if (i > 0) {
       bits = bits >>> i;
     }
-    // console.log(bits.toString(2))
     if (j > 0) {
       bits = bits << j;
     }
-    // console.log(bits.toString(2))
+
     T.arr[t] = T.arr[t] | bits
 
     var bitsAdded = Math.min(BITS_PER_INT-j,sourceWordLength - i);

--- a/app/BitSet.js
+++ b/app/BitSet.js
@@ -228,10 +228,10 @@ BitSet.prototype.circularShift = function(offset) {
   var z = 0; // bit index for entire sequence.
 
   offset = (BITS + (offset % BITS)) % BITS // positive, within length
-  var s = Math.floor(offset / BITS_PER_INT) % WORDS
+  var s = ~~(offset / BITS_PER_INT) % WORDS
   var i = offset % BITS_PER_INT
   while (z < BITS){
-    var sourceWordLength = s == WORDS - 1 ? BITS_LAST_WORD : BITS_PER_INT
+    var sourceWordLength = s === WORDS - 1 ? BITS_LAST_WORD : BITS_PER_INT
     var bits = S.arr[s]
 
     if (i > 0) {
@@ -254,7 +254,7 @@ BitSet.prototype.circularShift = function(offset) {
     if(i >= sourceWordLength){ i = 0; s++;}
     if(s >= WORDS){ s -= WORDS;}
   }
-  T.arr[WORDS-1] = T.arr[WORDS-1] & (MASK_SIGN >>> (31-BITS_LAST_WORD));
+  T.arr[WORDS-1] = T.arr[WORDS-1] & (MASK_SIGN >>> (BITS_PER_INT-BITS_LAST_WORD));
   return T;
 };
 

--- a/app/BitSet.js
+++ b/app/BitSet.js
@@ -204,6 +204,24 @@ BitSet.prototype.forEach = function (func) {
     func(i);
   }
 };
+
+/**
+ * Rotate a bitset by an offset
+ * @param {Number} index of current bitset that will be rotated to index 0 in the new bitset
+ * @returns {Bitset} a new bitset that is rotated by the offset
+ */
+BitSet.prototype.rotate = function (offset) {
+  var original = this;
+  const LEN = original.MAX_BIT+1
+  offset = LEN + (offset%LEN); // make offset positive, i.e. -300 ~= 1 (mod 7)
+  var rotated = new BitSet(LEN+1);
+  original.forEach(function(i){
+    rotated.set(i+offset % LEN)
+  })
+  return rotated;
+};
+
+
 /**
  * Get the cardinality (count of set bits) for the entire bitset
  * @returns {number} cardinality

--- a/spec/BitsetSpec.js
+++ b/spec/BitsetSpec.js
@@ -241,30 +241,33 @@ describe("BitSet", function () {
     expect(bs.set(899, true)).toBe(true);
     expect(bs.get(899)).toBe(true);
   });
-
+  //
   it('should rotate a small bitset', function () {
-    var bs = new BitSet(5);
-    bs.set(0);
-    expect(bs.get(0)).toBe(true);
-    expect(bs.circularShift(3).get(3)).toBe(true);
-    expect(bs.circularShift(10).get(0)).toBe(true);
-    expect(bs.circularShift(-10).get(0)).toBe(true);
-    expect(bs.circularShift(-1).get(4)).toBe(true);
-    expect(bs.circularShift(-7).get(3)).toBe(true);
-    expect(bs.circularShift(-7).get(6)).toBe(false);
+    var bs = new BitSet(63);
+    bs.set(30);
+    expect(bs.get(30)).toBe(true);
+    expect(bs.circularShift(1).get(31)).toBe(true);
+    expect(bs.circularShift(2).get(32)).toBe(true);
+    expect(bs.circularShift(3).get(33)).toBe(true);
   });
 
   it('should rotate a large bitset', function () {
-    var size = 40;
+    var size = 70;
     var evens = []; for (i=0; i<size/2; i++){evens.push(2*i)}
     var evenBitset = new BitSet(size);
-    for (i=0; i<25; i++){evenBitset.set(2*i)}
+    for (i=0; i<size; i++){evenBitset.set(2*i)}
 
     var odds = [];  for (i=0; i<size/2; i++){odds.push(2*i+1)}
     var oddBitset = new BitSet(size);
-    for (i=0; i<25; i++){oddBitset.set(2*i+1)}
+    for (i=0; i<size; i++){oddBitset.set(2*i+1)}
 
-    expect(evenBitset.circularShift(1).getIndices()).toEqual(odds)
+    expect(evenBitset.circularShift(1).isEqual(oddBitset)).toBe(true)
+    expect(evenBitset.circularShift(2).isEqual(evenBitset)).toBe(true)
+    expect(evenBitset.circularShift(3).isEqual(oddBitset)).toBe(true)
+    expect(evenBitset.circularShift(20).isEqual(evenBitset)).toBe(true)
+    expect(evenBitset.circularShift(31).isEqual(oddBitset)).toBe(true)
+    expect(evenBitset.circularShift(200).isEqual(evenBitset)).toBe(true)
+    expect(evenBitset.circularShift(-301).isEqual(oddBitset)).toBe(true)
   });
 
 });

--- a/spec/BitsetSpec.js
+++ b/spec/BitsetSpec.js
@@ -254,16 +254,17 @@ describe("BitSet", function () {
     expect(bs.circularShift(-7).get(6)).toBe(false);
   });
 
-  it('should rotate large bitset', function () {
-    var bs = new BitSet(500);
-    bs.set(0);
-    expect(bs.get(0)).toBe(true);
-    expect(bs.circularShift(300).get(300)).toBe(true);
-    expect(bs.circularShift(1000).get(0)).toBe(true);
-    expect(bs.circularShift(-500).get(0)).toBe(true);
-    expect(bs.circularShift(200).get(200)).toBe(true);
-    expect(bs.circularShift(-50).get(450)).toBe(true);
-    expect(bs.circularShift(-775).get(123)).toBe(false);
+  it('should rotate a large bitset', function () {
+    var size = 40;
+    var evens = []; for (i=0; i<size/2; i++){evens.push(2*i)}
+    var evenBitset = new BitSet(size);
+    for (i=0; i<25; i++){evenBitset.set(2*i)}
+
+    var odds = [];  for (i=0; i<size/2; i++){odds.push(2*i+1)}
+    var oddBitset = new BitSet(size);
+    for (i=0; i<25; i++){oddBitset.set(2*i+1)}
+
+    expect(evenBitset.circularShift(1).getIndices()).toEqual(odds)
   });
-  
+
 });

--- a/spec/BitsetSpec.js
+++ b/spec/BitsetSpec.js
@@ -242,32 +242,30 @@ describe("BitSet", function () {
     expect(bs.get(899)).toBe(true);
   });
   //
-  it('should rotate a small bitset', function () {
-    var bs = new BitSet(35);
-    bs.set(30);
-    expect(bs.get(30)).toBe(true);
-    expect(bs.circularShift(1).get(31)).toBe(true);
-    expect(bs.circularShift(2).get(32)).toBe(true);
-    expect(bs.circularShift(3).get(33)).toBe(true);
-  });
+  it('should rotate a bitset', function () {
 
-  it('should rotate a large bitset', function () {
-    var size = 70;
-    var evens = []; for (i=0; i<size/2; i++){evens.push(2*i)}
-    var evenBitset = new BitSet(size);
-    for (i=0; i<size; i++){evenBitset.set(2*i)}
+    var sizes = [10,34,70,500];
+    for(var i=0; i<sizes.length; i++) {
+      var size = sizes[i];
+      var evens = []; for (i=0; i<size/2; i++){evens.push(2*i)}
+      var evenBitset = new BitSet(size);
+      for (i=0; i<size; i++){evenBitset.set(2*i)}
 
-    var odds = [];  for (i=0; i<size/2; i++){odds.push(2*i+1)}
-    var oddBitset = new BitSet(size);
-    for (i=0; i<size; i++){oddBitset.set(2*i+1)}
+      var odds = [];  for (i=0; i<size/2; i++){odds.push(2*i+1)}
+      var oddBitset = new BitSet(size);
+      for (i=0; i<size; i++){oddBitset.set(2*i+1)}
 
-    expect(evenBitset.circularShift(1).isEqual(oddBitset)).toBe(true)
-    expect(evenBitset.circularShift(2).isEqual(evenBitset)).toBe(true)
-    expect(evenBitset.circularShift(3).isEqual(oddBitset)).toBe(true)
-    expect(evenBitset.circularShift(20).isEqual(evenBitset)).toBe(true)
-    expect(evenBitset.circularShift(31).isEqual(oddBitset)).toBe(true)
-    expect(evenBitset.circularShift(200).isEqual(evenBitset)).toBe(true)
-    expect(evenBitset.circularShift(-301).isEqual(oddBitset)).toBe(true)
+      expect(evenBitset.getCardinality() == evenBitset.circularShift(5).getCardinality()).toBe(true)
+      expect(evenBitset.circularShift(0).isEqual(evenBitset)).toBe(true)
+      expect(evenBitset.circularShift(size).isEqual(evenBitset)).toBe(true)
+      expect(evenBitset.circularShift(1).isEqual(oddBitset)).toBe(true)
+      expect(evenBitset.circularShift(size+1).isEqual(oddBitset)).toBe(true)
+      expect(evenBitset.circularShift(2).isEqual(evenBitset)).toBe(true)
+      expect(evenBitset.circularShift(size+2).isEqual(evenBitset)).toBe(true)
+      expect(evenBitset.circularShift(-size-3).isEqual(oddBitset)).toBe(true)
+      expect(evenBitset.circularShift(200).isEqual(evenBitset)).toBe(true)
+      expect(evenBitset.circularShift(-301).isEqual(oddBitset)).toBe(true)
+    }
   });
 
 });

--- a/spec/BitsetSpec.js
+++ b/spec/BitsetSpec.js
@@ -235,10 +235,22 @@ describe("BitSet", function () {
   });
 
   it('should set bit success which read from dehydrate string', function () {
-    
+
     var bs = new BitSet('2147483646,2147483647,2147483647,2147483647,2147483647,2147483647,2147483647,2147483647,2147483647,2147483647,2147483647,2147483647,2147483647,2147483647,2147483647,2147483647,2147483647,2147483647,2147483647,2147483647,2147483647,2147483647,2147483647,2147483647,2147483647,2147483647,2147483647,2147483647,2147483647,0,9999999');
     expect(bs.get(899)).toBe(false);
     expect(bs.set(899, true)).toBe(true);
     expect(bs.get(899)).toBe(true);
+  });
+
+  it('should rotate a bitset', function () {
+    var bs = new BitSet(5);
+    bs.set(0);
+    expect(bs.get(0)).toBe(true);
+    expect(bs.rotate(3).get(3)).toBe(true);
+    expect(bs.rotate(10).get(0)).toBe(true);
+    expect(bs.rotate(-10).get(0)).toBe(true);
+    expect(bs.rotate(-1).get(4)).toBe(true);
+    expect(bs.rotate(-7).get(3)).toBe(true);
+    expect(bs.rotate(-7).get(6)).toBe(false);
   });
 });

--- a/spec/BitsetSpec.js
+++ b/spec/BitsetSpec.js
@@ -265,6 +265,5 @@ describe("BitSet", function () {
     expect(bs.circularShift(-50).get(450)).toBe(true);
     expect(bs.circularShift(-775).get(123)).toBe(false);
   });
-
-
+  
 });

--- a/spec/BitsetSpec.js
+++ b/spec/BitsetSpec.js
@@ -242,15 +242,29 @@ describe("BitSet", function () {
     expect(bs.get(899)).toBe(true);
   });
 
-  it('should rotate a bitset', function () {
+  it('should rotate a small bitset', function () {
     var bs = new BitSet(5);
     bs.set(0);
     expect(bs.get(0)).toBe(true);
-    expect(bs.rotate(3).get(3)).toBe(true);
-    expect(bs.rotate(10).get(0)).toBe(true);
-    expect(bs.rotate(-10).get(0)).toBe(true);
-    expect(bs.rotate(-1).get(4)).toBe(true);
-    expect(bs.rotate(-7).get(3)).toBe(true);
-    expect(bs.rotate(-7).get(6)).toBe(false);
+    expect(bs.circularShift(3).get(3)).toBe(true);
+    expect(bs.circularShift(10).get(0)).toBe(true);
+    expect(bs.circularShift(-10).get(0)).toBe(true);
+    expect(bs.circularShift(-1).get(4)).toBe(true);
+    expect(bs.circularShift(-7).get(3)).toBe(true);
+    expect(bs.circularShift(-7).get(6)).toBe(false);
   });
+
+  it('should rotate large bitset', function () {
+    var bs = new BitSet(500);
+    bs.set(0);
+    expect(bs.get(0)).toBe(true);
+    expect(bs.circularShift(300).get(300)).toBe(true);
+    expect(bs.circularShift(1000).get(0)).toBe(true);
+    expect(bs.circularShift(-500).get(0)).toBe(true);
+    expect(bs.circularShift(200).get(200)).toBe(true);
+    expect(bs.circularShift(-50).get(450)).toBe(true);
+    expect(bs.circularShift(-775).get(123)).toBe(false);
+  });
+
+
 });

--- a/spec/BitsetSpec.js
+++ b/spec/BitsetSpec.js
@@ -243,7 +243,7 @@ describe("BitSet", function () {
   });
   //
   it('should rotate a small bitset', function () {
-    var bs = new BitSet(63);
+    var bs = new BitSet(35);
     bs.set(30);
     expect(bs.get(30)).toBe(true);
     expect(bs.circularShift(1).get(31)).toBe(true);


### PR DESCRIPTION
This is a very simple implementation of bitset rotation.  I don't think it's as fast as it could be, but it's more than fast enough for my purposes.

In [contemporary music theory](https://en.wikipedia.org/wiki/Post-tonal_music_theory), bitsets can be used to represent collections of pitches as subsets of a [cyclic order](https://en.wikipedia.org/wiki/Cyclic_order).

If `~` is used to mean equivalency, then in music theory, the following bitsets would in certain situations be thought of as equivalent: `1000 ~ 0100 ~ 0010 ~ 0001`.  In a 12-tone tuning system, you'd typically be working with length 12 bitsets, such as `101011010101`.

I didn't want to dig in too deeply, but if I were to do this "properly", maybe I'd build in rotation shifting in as a non-destructive modifier of BitSets, so that calling BitSet.get(idx) and BitSet.set(idx) would do an index shift, rather than copying onto a whole new BitSet.  But since I'm unfamiliar with the functions used in the rest of the library, I didn't have the motivation to get into it like that.  Plus, I'm going to be working with very small bitsets for now.
